### PR TITLE
Make source JDK 6 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.iml
 *.log
 .DS_Store
+*.swp

--- a/config/src/main/java/org/wildfly/extras/config/ConfigContext.java
+++ b/config/src/main/java/org/wildfly/extras/config/ConfigContext.java
@@ -15,28 +15,28 @@
  */
 package org.wildfly.extras.config;
 
-import java.nio.file.Path;
+import java.io.File;
 
 import org.jdom.Document;
 
 
 public final class ConfigContext {
 
-    private final Path jbossHome;
-    private final Path configuration;
+    private final File jbossHome;
+    private final File configuration;
     private final Document document;
 
-    ConfigContext(Path jbossHome, Path configuration, Document document) {
+    ConfigContext(File jbossHome, File configuration, Document document) {
         this.jbossHome = jbossHome;
         this.configuration = configuration;
         this.document = document;
     }
 
-    public Path getJBossHome() {
+    public File getJBossHome() {
         return jbossHome;
     }
 
-    public Path getConfiguration() {
+    public File getConfiguration() {
         return configuration;
     }
 

--- a/config/src/main/java/org/wildfly/extras/config/NamespaceRegistry.java
+++ b/config/src/main/java/org/wildfly/extras/config/NamespaceRegistry.java
@@ -28,7 +28,7 @@ import org.jdom.Namespace;
 import org.wildfly.extras.config.internal.IllegalArgumentAssertion;
 
 public class NamespaceRegistry {
-    private Map<String, List<Namespace>> namespaces = new LinkedHashMap<>();
+    private Map<String, List<Namespace>> namespaces = new LinkedHashMap<String, List<Namespace>>();
 
     public void registerNamespace(String namespace, String version) {
         if (!namespaces.containsKey(namespace)) {

--- a/config/src/main/java/org/wildfly/extras/config/internal/Main.java
+++ b/config/src/main/java/org/wildfly/extras/config/internal/Main.java
@@ -39,7 +39,7 @@ public class Main {
     }
 
     // Entry point with no system exit
-    public static void mainInternal(String[] args) throws Exception {
+    public static void mainInternal(String[] args) throws Throwable {
         
         Options options = new Options();
         CmdLineParser parser = new CmdLineParser(options);
@@ -51,7 +51,7 @@ public class Main {
         }
 
         try {
-            List<String> configs = new ArrayList<>();
+            List<String> configs = new ArrayList<String>();
             if (options.configs != null) {
                 configs.addAll(Arrays.asList(options.configs.split(",")));
             }

--- a/core/src/main/java/org/wildfly/extras/patch/Configuration.java
+++ b/core/src/main/java/org/wildfly/extras/patch/Configuration.java
@@ -19,12 +19,11 @@
  */
 package org.wildfly.extras.patch;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.wildfly.extras.patch.aether.AetherFactory;
@@ -37,7 +36,7 @@ public final class Configuration {
     public static final String PROPERTY_REPOSITORY_PASSWORD = "repository.password";
     public static final String PROPERTY_AETHER_FACTORY = "aether.factory";
 
-    private Path serverPath;
+    private File serverPath;
     private URL repoUrl;
     private String aetherFactory;
     private String username;
@@ -49,8 +48,11 @@ public final class Configuration {
 
     public static Configuration load(URL configURL) throws IOException {
         Properties props = new Properties();
-        try (InputStream input = configURL.openStream()) {
+        InputStream input = configURL.openStream();
+        try {
             props.load(input);
+        } finally {
+            input.close();
         }
         return load(props);
     }
@@ -59,7 +61,7 @@ public final class Configuration {
         Configuration config = new Configuration();
         String propval = props.getProperty(PROPERTY_SERVER_HOME);
         if (propval != null) {
-            config.serverPath = Paths.get(propval);
+            config.serverPath = new File(propval);
         }
         propval = props.getProperty(PROPERTY_REPOSITORY_URL);
         if (propval != null) {

--- a/core/src/main/java/org/wildfly/extras/patch/ManagedPath.java
+++ b/core/src/main/java/org/wildfly/extras/patch/ManagedPath.java
@@ -19,8 +19,7 @@
  */
 package org.wildfly.extras.patch;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,18 +36,18 @@ import org.wildfly.extras.patch.utils.IllegalArgumentAssertion;
  */
 public final class ManagedPath {
 
-    private final Path path;
-    private final List<PatchId> owners = new ArrayList<>();
+    private final File path;
+    private final List<PatchId> owners = new ArrayList<PatchId>();
 
-    public static ManagedPath create(Path path, List<PatchId> owners) {
+    public static ManagedPath create(File path, List<PatchId> owners) {
         return new ManagedPath(path, owners);
     }
 
     public static ManagedPath fromString(String line) {
         IllegalArgumentAssertion.assertNotNull(line, "line");
         int index = line.indexOf(' ');
-        List<PatchId> owners = new ArrayList<>();
-        Path path = Paths.get(line.substring(0, index));
+        List<PatchId> owners = new ArrayList<PatchId>();
+        File path = new File(line.substring(0, index));
         String opart = line.substring(index + 1);
         opart = opart.substring(1, opart.length() - 1);
         for (String idspec : opart.split(",")) {
@@ -57,14 +56,14 @@ public final class ManagedPath {
         return new ManagedPath(path, owners);
     }
     
-    private ManagedPath(Path path, List<PatchId> owners) {
+    private ManagedPath(File path, List<PatchId> owners) {
         IllegalArgumentAssertion.assertNotNull(path, "path");
         IllegalArgumentAssertion.assertNotNull(owners, "owners");
         this.path = path;
         this.owners.addAll(owners);
     }
 
-    public Path getPath() {
+    public File getPath() {
         return path;
     }
 

--- a/core/src/main/java/org/wildfly/extras/patch/Patch.java
+++ b/core/src/main/java/org/wildfly/extras/patch/Patch.java
@@ -19,7 +19,7 @@
  */
 package org.wildfly.extras.patch;
 
-import java.nio.file.Path;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,7 +44,7 @@ import org.wildfly.extras.patch.utils.IllegalArgumentAssertion;
 public final class Patch {
 
     private final PatchMetadata metadata;
-    private final Map<Path, Record> recordsMap = new LinkedHashMap<>();
+    private final Map<File, Record> recordsMap = new LinkedHashMap<File, Record>();
     private int hashCache;
 
     public static Patch create(PatchMetadata metadata, Collection<Record> records) {
@@ -55,16 +55,16 @@ public final class Patch {
         IllegalArgumentAssertion.assertNotNull(targetSet, "targetSet");
 
         // All seed patch records are remove candidates
-        Map<Path, Record> removeMap = new HashMap<>();
+        Map<File, Record> removeMap = new HashMap<File, Record>();
         if (seedPatch != null) {
             for (Record rec : seedPatch.getRecords()) {
                 removeMap.put(rec.getPath(), Record.create(null, Action.DEL, rec.getPath(), rec.getChecksum()));
             }
         }
 
-        Set<Record> records = new HashSet<>();
+        Set<Record> records = new HashSet<Record>();
         for (Record rec : targetSet.getRecords()) {
-            Path path = rec.getPath();
+            File path = rec.getPath();
             Long checksum = rec.getChecksum();
             if (removeMap.containsValue(rec)) {
                 removeMap.remove(path);
@@ -88,13 +88,13 @@ public final class Patch {
         this.metadata = metadata;
 
         // Sort the records by path
-        Map<Path, Record> auxmap = new HashMap<>();
+        Map<File, Record> auxmap = new HashMap<File, Record>();
         for (Record aux : records) {
             auxmap.put(aux.getPath(), Record.create(metadata.getPatchId(), aux.getAction(), aux.getPath(), aux.getChecksum()));
         }
-        List<Path> paths = new ArrayList<>(auxmap.keySet());
+        List<File> paths = new ArrayList<File>(auxmap.keySet());
         Collections.sort(paths);
-        for (Path path : paths) {
+        for (File path : paths) {
             recordsMap.put(path, auxmap.get(path));
         }
     }
@@ -108,14 +108,14 @@ public final class Patch {
     }
 
     public List<Record> getRecords() {
-        return Collections.unmodifiableList(new ArrayList<>(recordsMap.values()));
+        return Collections.unmodifiableList(new ArrayList<Record>(recordsMap.values()));
     }
 
-    public boolean containsPath(Path path) {
+    public boolean containsPath(File path) {
         return recordsMap.containsKey(path);
     }
 
-    public Record getRecord(Path path) {
+    public Record getRecord(File path) {
         return recordsMap.get(path);
     }
 

--- a/core/src/main/java/org/wildfly/extras/patch/PatchMetadata.java
+++ b/core/src/main/java/org/wildfly/extras/patch/PatchMetadata.java
@@ -34,9 +34,9 @@ public final class PatchMetadata {
 
     private final PatchId patchId;
     private final PatchId oneoffId;
-    private final Set<String> roles = new LinkedHashSet<>();
-    private final Set<PatchId> dependencies = new LinkedHashSet<>();
-    private final List<String> commands = new ArrayList<>();
+    private final Set<String> roles = new LinkedHashSet<String>();
+    private final Set<PatchId> dependencies = new LinkedHashSet<PatchId>();
+    private final List<String> commands = new ArrayList<String>();
     private final String stringCache;
     
     PatchMetadata(PatchId patchId, Set<String> roles, PatchId oneoffId, Set<PatchId> dependencies, List<String> commands) {

--- a/core/src/main/java/org/wildfly/extras/patch/PatchMetadataBuilder.java
+++ b/core/src/main/java/org/wildfly/extras/patch/PatchMetadataBuilder.java
@@ -29,9 +29,9 @@ public final class PatchMetadataBuilder {
 
     private PatchId patchId;
     private PatchId oneoffId;
-    private Set<String> roles = new LinkedHashSet<>();
-    private Set<PatchId> dependencies = new LinkedHashSet<>();
-    private List<String> postCommands = new ArrayList<>();
+    private Set<String> roles = new LinkedHashSet<String>();
+    private Set<PatchId> dependencies = new LinkedHashSet<PatchId>();
+    private List<String> postCommands = new ArrayList<String>();
 
     public PatchMetadataBuilder patchId(PatchId patchId) {
         this.patchId = patchId;

--- a/core/src/main/java/org/wildfly/extras/patch/PatchTool.java
+++ b/core/src/main/java/org/wildfly/extras/patch/PatchTool.java
@@ -37,7 +37,8 @@ public abstract class PatchTool {
     public static final Version VERSION;
     static {
         Version versionProp = null;
-        try (InputStream input = SmartPatch.class.getResourceAsStream("version.properties")) {
+        InputStream input = SmartPatch.class.getResourceAsStream("version.properties");
+        try {
             BufferedReader br = new BufferedReader(new InputStreamReader(input));
             String line = br.readLine();
             while (line != null) {

--- a/core/src/main/java/org/wildfly/extras/patch/PatchToolBuilder.java
+++ b/core/src/main/java/org/wildfly/extras/patch/PatchToolBuilder.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.file.Path;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.wildfly.extras.patch.aether.AetherFactory;
@@ -47,7 +46,7 @@ public final class PatchToolBuilder {
 
     private ReentrantLock lock = new ReentrantLock();
     private URL repoUrl;
-    private Path serverPath;
+    private File serverPath;
     private ServerFactory serverFactory;
     private AetherFactory aetherFactory;
     private String username;
@@ -68,7 +67,7 @@ public final class PatchToolBuilder {
         return this;
     }
 
-    public PatchToolBuilder serverPath(Path serverPath) {
+    public PatchToolBuilder serverPath(File serverPath) {
         this.serverPath = serverPath;
         return this;
     }
@@ -139,7 +138,7 @@ public final class PatchToolBuilder {
 
                 // Local file repository
                 if (protocol.equals("file")) {
-                    Path rootPath = getAbsolutePath(repoUrl);
+                    File rootPath = getAbsolutePath(repoUrl);
                     repository = new LocalFileRepository(lock, rootPath);
                 }
 
@@ -149,9 +148,9 @@ public final class PatchToolBuilder {
         return repository;
     }
 
-    private Path getAbsolutePath(URL url) {
+    private File getAbsolutePath(URL url) {
         try {
-            return new File(URLDecoder.decode(url.getPath(), "UTF-8")).getAbsoluteFile().toPath();
+            return new File(URLDecoder.decode(url.getPath(), "UTF-8")).getAbsoluteFile();
         } catch (UnsupportedEncodingException ex) {
             throw new IllegalArgumentException(ex);
         }

--- a/core/src/main/java/org/wildfly/extras/patch/Record.java
+++ b/core/src/main/java/org/wildfly/extras/patch/Record.java
@@ -19,8 +19,7 @@
  */
 package org.wildfly.extras.patch;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.File;
 
 import org.wildfly.extras.patch.utils.IllegalArgumentAssertion;
 import org.wildfly.extras.patch.utils.IllegalStateAssertion;
@@ -41,18 +40,18 @@ public final class Record {
 
     private final PatchId patchId;
     private final Record.Action action;
-    private final Path path;
+    private final File path;
     private final Long checksum;
 
-    public static Record create(Path path) {
+    public static Record create(File path) {
         return new Record(null, Action.INFO, path, 0L);
     }
 
-    public static Record create(Path path, Long checksum) {
+    public static Record create(File path, Long checksum) {
         return new Record(null, Action.INFO, path, checksum);
     }
     
-    public static Record create(PatchId patchId, Action action, Path path, Long checksum) {
+    public static Record create(PatchId patchId, Action action, File path, Long checksum) {
         return new Record(patchId, action, path, checksum);
     }
 
@@ -60,10 +59,10 @@ public final class Record {
         IllegalArgumentAssertion.assertNotNull(line, "line");
         String[] toks = line.split("[\\s]");
         IllegalStateAssertion.assertEquals(3, toks.length, "Invalid line: " + line);
-        return new Record(null, Record.Action.valueOf(toks[0]), Paths.get(toks[1]), new Long(toks[2]));
+        return new Record(null, Record.Action.valueOf(toks[0]), new File(toks[1]), new Long(toks[2]));
     }
     
-    private Record(PatchId patchId, Action action, Path path, Long checksum) {
+    private Record(PatchId patchId, Action action, File path, Long checksum) {
         IllegalArgumentAssertion.assertNotNull(action, "action");
         IllegalArgumentAssertion.assertNotNull(path, "path");
         IllegalArgumentAssertion.assertNotNull(checksum, "checksum");
@@ -81,7 +80,7 @@ public final class Record {
         return action;
     }
 
-    public Path getPath() {
+    public File getPath() {
         return path;
     }
 

--- a/core/src/main/java/org/wildfly/extras/patch/Server.java
+++ b/core/src/main/java/org/wildfly/extras/patch/Server.java
@@ -19,9 +19,9 @@
  */
 package org.wildfly.extras.patch;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -38,7 +38,7 @@ public interface Server {
 	 * Get the server home path
 	 * @return The path to the server home
 	 */
-	Path getServerHome();
+	File getServerHome();
 	
 	/**
 	 * Get the default repository URL

--- a/core/src/main/java/org/wildfly/extras/patch/SmartPatch.java
+++ b/core/src/main/java/org/wildfly/extras/patch/SmartPatch.java
@@ -20,8 +20,8 @@
 package org.wildfly.extras.patch;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,9 +49,9 @@ public final class SmartPatch implements Closeable {
 
     private final Patch patch;
     private final DataHandler dataHandler;
-    private final Map<Path, Record> delMap = new HashMap<>();
-    private final Map<Path, Record> updMap = new HashMap<>();
-    private final Map<Path, Record> addMap = new HashMap<>();
+    private final Map<File, Record> delMap = new HashMap<File, Record>();
+    private final Map<File, Record> updMap = new HashMap<File, Record>();
+    private final Map<File, Record> addMap = new HashMap<File, Record>();
     
     public static SmartPatch forInstall(Patch patch, DataHandler dataHandler) {
         IllegalArgumentAssertion.assertNotNull(dataHandler, "dataHandler");
@@ -61,7 +61,7 @@ public final class SmartPatch implements Closeable {
     public static SmartPatch forUninstall(Patch patch) {
         IllegalArgumentAssertion.assertNotNull(patch, "patch");
         PatchId patchId = patch.getPatchId();
-        List<Record> records = new ArrayList<>();
+        List<Record> records = new ArrayList<Record>();
         for (Record rec : patch.getRecords()) {
             records.add(Record.create(patchId, Action.DEL, rec.getPath(), rec.getChecksum()));
         }
@@ -115,26 +115,26 @@ public final class SmartPatch implements Closeable {
     }
     
     public Set<Record> getRemoveSet() {
-        return Collections.unmodifiableSet(new HashSet<>(delMap.values()));
+        return Collections.unmodifiableSet(new HashSet<Record>(delMap.values()));
     }
 
-    public boolean isRemovePath(Path path) {
+    public boolean isRemovePath(File path) {
         return delMap.containsKey(path);
     }
 
 	public Set<Record> getReplaceSet() {
-        return Collections.unmodifiableSet(new HashSet<>(updMap.values()));
+        return Collections.unmodifiableSet(new HashSet<Record>(updMap.values()));
 	}
 
-    public boolean isReplacePath(Path path) {
+    public boolean isReplacePath(File path) {
         return updMap.containsKey(path);
     }
 
 	public Set<Record> getAddSet() {
-        return Collections.unmodifiableSet(new HashSet<>(addMap.values()));
+        return Collections.unmodifiableSet(new HashSet<Record>(addMap.values()));
 	}
 
-    public boolean isAddPath(Path path) {
+    public boolean isAddPath(File path) {
         return addMap.containsKey(path);
     }
 

--- a/core/src/main/java/org/wildfly/extras/patch/aether/AetherFactory.java
+++ b/core/src/main/java/org/wildfly/extras/patch/aether/AetherFactory.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.wildfly.extras.patch.aether;
 
+import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -21,7 +21,7 @@ public interface AetherFactory {
 
     URL getRepositoryURL();
     
-    Path getLocalRepositoryPath();
+    File getLocalRepositoryPath();
     
     RepositorySystem getRepositorySystem();
     

--- a/core/src/main/java/org/wildfly/extras/patch/aether/DefaultAetherFactory.java
+++ b/core/src/main/java/org/wildfly/extras/patch/aether/DefaultAetherFactory.java
@@ -37,7 +37,7 @@ public abstract class DefaultAetherFactory implements AetherFactory {
         if (system == null) {
             system = ManualRepositorySystemFactory.newRepositorySystem();
             repository = new RemoteRepository.Builder("fusepatch.repository", "default", getRepositoryURL().toString()).build();
-            localRepo = new LocalRepository(getLocalRepositoryPath().toFile());
+            localRepo = new LocalRepository(getLocalRepositoryPath());
         }
         return system;
     }

--- a/core/src/main/java/org/wildfly/extras/patch/internal/DefaultPatchTool.java
+++ b/core/src/main/java/org/wildfly/extras/patch/internal/DefaultPatchTool.java
@@ -97,8 +97,11 @@ public final class DefaultPatchTool extends PatchTool {
             PatchAssertion.assertNotNull(installed, "Patch not installed: " + patchId);
             PatchId latestId = getServer().getPatch(patchId.getName()).getPatchId();
             PatchAssertion.assertEquals(patchId, latestId, "Active package is " + latestId + ", cannot uninstall: " + patchId);
-            try (SmartPatch smartPatch = SmartPatch.forUninstall(installed)) {
+            SmartPatch smartPatch = SmartPatch.forUninstall(installed);
+            try {
                 return getServer().applySmartPatch(smartPatch, false);
+            } finally {
+                smartPatch.close();
             }
         } finally {
             lock.unlock();
@@ -117,8 +120,11 @@ public final class DefaultPatchTool extends PatchTool {
         }
 
         Patch seedPatch = serverId != null ? getServer().getPatch(serverId) : null;
-        try (SmartPatch smartPatch = getRepository().getSmartPatch(seedPatch, patchId)) {
+        SmartPatch smartPatch = getRepository().getSmartPatch(seedPatch, patchId);
+        try {
             return getServer().applySmartPatch(smartPatch, force);
+        } finally {
+            smartPatch.close();
         }
     }
 

--- a/core/src/main/java/org/wildfly/extras/patch/internal/Main.java
+++ b/core/src/main/java/org/wildfly/extras/patch/internal/Main.java
@@ -59,7 +59,7 @@ public class Main {
     }
 
     // Entry point with no system exit
-    public static void mainInternal(String[] args) throws Exception {
+    public static void mainInternal(String[] args) throws Throwable {
         
         Options options = new Options();
         CmdLineParser parser = new CmdLineParser(options);
@@ -120,7 +120,7 @@ public class Main {
         // Query the server paths
         if (options.queryServerPaths != null) {
             PatchTool patchTool = builder.serverPath(options.serverHome).build();
-            List<String> managedPaths = new ArrayList<>();
+            List<String> managedPaths = new ArrayList<String>();
             for (ManagedPath managedPath : patchTool.getServer().queryManagedPaths(options.queryServerPaths)) {
                 managedPaths.add(managedPath.toString());
             }
@@ -201,7 +201,7 @@ public class Main {
         
         if (options.dependencies != null) {
             IllegalStateAssertion.assertTrue(metadata.getDependencies().isEmpty(), "Dependencies already defined: " + metadata);
-            Set<PatchId> dependencies = new LinkedHashSet<>();
+            Set<PatchId> dependencies = new LinkedHashSet<PatchId>();
             for (String depid : options.dependencies) {
                 dependencies.add(PatchId.fromString(depid));
             }

--- a/core/src/main/java/org/wildfly/extras/patch/internal/Options.java
+++ b/core/src/main/java/org/wildfly/extras/patch/internal/Options.java
@@ -19,8 +19,8 @@
  */
 package org.wildfly.extras.patch.internal;
 
+import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
 
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
@@ -34,7 +34,7 @@ final class Options {
     URL configUrl;
     
 	@Option(name = "--server", usage = "Path to the target server")
-	Path serverHome;
+	File serverHome;
 
 	@Option(name = "--repository", usage = "URL to the patch repository")
 	URL repositoryUrl;

--- a/core/src/main/java/org/wildfly/extras/patch/internal/PatchMetadataModel.java
+++ b/core/src/main/java/org/wildfly/extras/patch/internal/PatchMetadataModel.java
@@ -133,7 +133,7 @@ public final class PatchMetadataModel {
         }
 
         public Roles(Set<String> roles) {
-            this.roles = new LinkedHashSet<>(roles);
+            this.roles = new LinkedHashSet<String>(roles);
         }
 
         public Set<String> getRoles() {
@@ -155,7 +155,7 @@ public final class PatchMetadataModel {
         }
 
         public Dependencies(Set<PatchId> dependencies) {
-            patchIds = new LinkedHashSet<> ();
+            patchIds = new LinkedHashSet<String> ();
             for (PatchId aux : dependencies) {
                 patchIds.add(aux.toString());
             }
@@ -180,7 +180,7 @@ public final class PatchMetadataModel {
         }
 
         public Commands(List<String> commands) {
-            this.commands = new ArrayList<>(commands);
+            this.commands = new ArrayList<String>(commands);
         }
 
         public List<String> getCommands() {

--- a/core/src/main/java/org/wildfly/extras/patch/repository/AbstractRepository.java
+++ b/core/src/main/java/org/wildfly/extras/patch/repository/AbstractRepository.java
@@ -27,19 +27,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -90,7 +86,7 @@ public abstract class AbstractRepository implements Repository {
         IllegalArgumentAssertion.assertNotNull(prefix, "prefix");
         lock.tryLock();
         try {
-            List<PatchId> list = new ArrayList<>(queryAvailable(prefix));
+            List<PatchId> list = new ArrayList<PatchId>(queryAvailable(prefix));
             Collections.sort(list);
             return list.isEmpty() ? null : list.get(list.size() - 1);
         } finally {
@@ -157,7 +153,7 @@ public abstract class AbstractRepository implements Repository {
             LOG.info(message);
             
             // Collect the paths from the latest other patches
-            Map<Path, Record> combinedPathsMap = new HashMap<>();
+            Map<File, Record> combinedPathsMap = new HashMap<File, Record>();
             for (PatchId auxid : queryAvailable(null)) {
                 if (!patchId.getName().equals(auxid.getName())) {
                     for (Record rec : getPatch(auxid).getRecords()) {
@@ -166,78 +162,112 @@ public abstract class AbstractRepository implements Repository {
                 }
             }
 
-            final Path targetPath = Files.createTempFile("fptmp", ".zip");
-            final File targetFile = targetPath.toFile();
+            final File targetPath = File.createTempFile("fptmp", ".zip");
+            final File targetFile = targetPath;
             
             // Copy regular patch content to a target file
             if (oneoffId == null) {
-                try (InputStream input = dataHandler.getInputStream(); OutputStream output = new FileOutputStream(targetFile)) {
-                    IOUtils.copy(input, output);
+                InputStream input = dataHandler.getInputStream();
+                OutputStream output = new FileOutputStream(targetFile);
+                try {
+                    try {
+                        IOUtils.copy(input, output);
+                    } finally {
+                        output.close();
+                    }
+                } finally {
+                    input.close();
                 }
             }
             
             // Combine oneoff base contant with patch content to a target file
             if (oneoffId != null) {
                 
-                final Path workspace = Files.createTempDirectory("oneoff-workspace");
+                final File workspaceFile = File.createTempFile("oneoff-workspace", "");
+                final File workspace = new File(workspaceFile.getPath() + ".d");
+                workspaceFile.delete();
+                workspace.mkdir();
                 try {
                     
                     // Unzip the base patch into the workspace
                     DataSource dataSource = getDataSource(oneoffId);
-                    try (ZipInputStream zipInput = new ZipInputStream(dataSource.getInputStream())) {
+                    ZipInputStream zipInput = new ZipInputStream(dataSource.getInputStream());
+                    try {
                         byte[] buffer = new byte[64 * 1024];
                         ZipEntry entry = zipInput.getNextEntry();
                         while (entry != null) {
                             if (!entry.isDirectory()) {
                                 String name = entry.getName();
-                                File entryFile = workspace.resolve(Paths.get(name)).toFile();
+                                File entryFile = new File(workspace, name);
                                 entryFile.getParentFile().mkdirs();
-                                try (FileOutputStream fos = new FileOutputStream(entryFile)) {
+                                FileOutputStream fos = new FileOutputStream(entryFile);
+                                try {
                                     int read = zipInput.read(buffer);
                                     while (read > 0) {
                                         fos.write(buffer, 0, read);
                                         read = zipInput.read(buffer);
                                     }
+                                } finally {
+                                    fos.close();
                                 }
                             }
                             entry = zipInput.getNextEntry();
                         }
+                    } finally {
+                        zipInput.close();
                     }
 
                     // Unzip the one-off patch into the workspace
-                    try (ZipInputStream zipInput = new ZipInputStream(dataHandler.getInputStream())) {
+                    zipInput = new ZipInputStream(dataHandler.getInputStream());
+                    try {
                         byte[] buffer = new byte[64 * 1024];
                         ZipEntry entry = zipInput.getNextEntry();
                         while (entry != null) {
                             if (!entry.isDirectory()) {
                                 String name = entry.getName();
-                                File entryFile = workspace.resolve(Paths.get(name)).toFile();
+                                File entryFile = new File(workspace, name);
                                 entryFile.getParentFile().mkdirs();
-                                try (FileOutputStream fos = new FileOutputStream(entryFile)) {
+                                FileOutputStream fos = new FileOutputStream(entryFile);
+                                try {
                                     int read = zipInput.read(buffer);
                                     while (read > 0) {
                                         fos.write(buffer, 0, read);
                                         read = zipInput.read(buffer);
                                     }
+                                } finally {
+                                    fos.close();
                                 }
                             }
                             entry = zipInput.getNextEntry();
                         }
+                    } finally {
+                        zipInput.close();
                     }
 
                     // Create the target zip file
-                    try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(targetFile))) {
-                        Files.walkFileTree(workspace, new SimpleFileVisitor<Path>() {
-                            @Override
-                            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
-                                Path relpath = workspace.relativize(path);
-                                zos.putNextEntry(new ZipEntry(relpath.toString()));
-                                try (FileInputStream fis = new FileInputStream(path.toFile())) {
-                                    IOUtils.copy(fis, zos);
+                    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(targetFile));
+                    try {
+                        LinkedList<File> dirs = new LinkedList<File>();
+                        dirs.push(workspace);
+                        File dir;
+                        while ((dir = dirs.poll()) != null) {
+                            for (File sub : dir.listFiles()) {
+                                if (sub.isDirectory()) {
+                                    dirs.push(sub);
+                                } else {
+                                    File relpath = new File(workspace.toURI().relativize(sub.toURI()));
+                                    zos.putNextEntry(new ZipEntry(relpath.toString()));
+                                    FileInputStream fis = new FileInputStream(sub);
+                                    try {
+                                        IOUtils.copy(fis, zos);
+                                    } finally {
+                                        fis.close();
+                                    }
                                 }
-                                return FileVisitResult.CONTINUE;
                             }
-                        });
+                        }
+                    } finally {
+                        zos.close();
                     }
                 } finally {
                     IOUtils.rmdirs(workspace);
@@ -246,13 +276,16 @@ public abstract class AbstractRepository implements Repository {
                 
             // Build the patch
             Patch patch;
-            try (ZipInputStream zipInput = new ZipInputStream(new FileInputStream(targetFile))) {
+            ZipInputStream zipInput = new ZipInputStream(new FileInputStream(targetFile));
+            try {
                 Patch source = MetadataParser.buildPatchFromZip(patchId, Record.Action.INFO, zipInput);
                 patch = Patch.create(metadata, source.getRecords());
+            } finally {
+                zipInput.close();
             }
             
             // Assert no duplicate paths
-            Set<PatchId> duplicates = new HashSet<>();
+            Set<PatchId> duplicates = new HashSet<PatchId>();
             for (Record rec : patch.getRecords()) {
                 Record otherRec = combinedPathsMap.get(rec.getPath());
                 if (otherRec != null) {
@@ -300,16 +333,18 @@ public abstract class AbstractRepository implements Repository {
 
     private CloseableDataSource getSmartDataSource(Patch smartSet, PatchId patchId) throws IOException {
         
-        final Path targetPath = Files.createTempFile("smart-content", ".zip");
+        final File targetPath = File.createTempFile("smart-content", ".zip");
         
         // Create a temporary zip file that only contains ADD && UPD records
         DataSource dataSource = getDataSource(patchId);
-        try (ZipInputStream zin = new ZipInputStream(dataSource.getInputStream())) {
-            try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(targetPath.toFile()))) {
+        ZipInputStream zin = new ZipInputStream(dataSource.getInputStream());
+        try {
+            ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(targetPath));
+            try {
                 byte[] buffer = new byte[64 * 1024];
                 ZipEntry entry = zin.getNextEntry();
                 while (entry != null) {
-                    Record rec = smartSet.getRecord(Paths.get(entry.getName()));
+                    Record rec = smartSet.getRecord(new File(entry.getName()));
                     if (!entry.isDirectory() && rec != null && (rec.getAction() == Action.ADD || rec.getAction() == Action.UPD)) {
                         zout.putNextEntry(new ZipEntry(entry.getName()));
                         int read = zin.read(buffer);
@@ -320,14 +355,18 @@ public abstract class AbstractRepository implements Repository {
                     }
                     entry = zin.getNextEntry();
                 }
+            } finally {
+                zout.close();
             }
+        } finally {
+            zin.close();
         }
         
-        DataSource datasource = new FileDataSource(targetPath.toFile());
+        DataSource datasource = new FileDataSource(targetPath);
         return new CloseableDataSource(datasource) {
             @Override
             public void close() throws IOException {
-                targetPath.toFile().delete();
+                targetPath.delete();
             }
         };
     }

--- a/core/src/main/java/org/wildfly/extras/patch/repository/AbstractRepository.java
+++ b/core/src/main/java/org/wildfly/extras/patch/repository/AbstractRepository.java
@@ -255,8 +255,7 @@ public abstract class AbstractRepository implements Repository {
                                 if (sub.isDirectory()) {
                                     dirs.push(sub);
                                 } else {
-                                    File relpath = new File(workspace.toURI().relativize(sub.toURI()));
-                                    zos.putNextEntry(new ZipEntry(relpath.toString()));
+                                    zos.putNextEntry(new ZipEntry(workspace.toURI().relativize(sub.toURI()).toString()));
                                     FileInputStream fis = new FileInputStream(sub);
                                     try {
                                         IOUtils.copy(fis, zos);

--- a/core/src/main/java/org/wildfly/extras/patch/repository/PatchAdapter.java
+++ b/core/src/main/java/org/wildfly/extras/patch/repository/PatchAdapter.java
@@ -48,7 +48,7 @@ public class PatchAdapter {
     
     public Patch toPatch() {
         PatchMetadata metadata = metadataSpec.toPatchMetadata();
-    	List<Record> records = new ArrayList<>();
+    	List<Record> records = new ArrayList<Record>();
     	for (String spec : recordSpecs) {
     		records.add(Record.fromString(spec));
     	}

--- a/core/src/main/java/org/wildfly/extras/patch/repository/PatchMetadataAdapter.java
+++ b/core/src/main/java/org/wildfly/extras/patch/repository/PatchMetadataAdapter.java
@@ -43,13 +43,13 @@ public class PatchMetadataAdapter {
     	PatchMetadataAdapter result = new PatchMetadataAdapter();
     	result.patchId = metadata.getPatchId().toString();
         
-        List<String> roles = new ArrayList<>(metadata.getRoles());
+        List<String> roles = new ArrayList<String>(metadata.getRoles());
         result.roles = new String[roles.size()];
         for (int i = 0; i < roles.size(); i++) {
             result.roles[i] = roles.get(i);
         }
         
-        List<PatchId> dependencies = new ArrayList<>(metadata.getDependencies());
+        List<PatchId> dependencies = new ArrayList<PatchId>(metadata.getDependencies());
         result.dependencySpecs = new String[dependencies.size()];
         for (int i = 0; i < dependencies.size(); i++) {
             result.dependencySpecs[i] = dependencies.get(i).toString();
@@ -63,7 +63,7 @@ public class PatchMetadataAdapter {
     
     public PatchMetadata toPatchMetadata() {
     	PatchId pid = PatchId.fromString(patchId);
-    	Set<PatchId> dependencies = new HashSet<>();
+    	Set<PatchId> dependencies = new HashSet<PatchId>();
     	if (dependencySpecs != null) {
         	for (String spec : dependencySpecs) {
         		dependencies.add(PatchId.fromString(spec));

--- a/core/src/main/java/org/wildfly/extras/patch/repository/RepositoryClient.java
+++ b/core/src/main/java/org/wildfly/extras/patch/repository/RepositoryClient.java
@@ -74,7 +74,7 @@ public final class RepositoryClient implements Repository {
     public List<PatchId> queryAvailable(String prefix) {
         lock.tryLock();
         try {
-            List<PatchId> result = new ArrayList<>();
+            List<PatchId> result = new ArrayList<PatchId>();
             String[] available = delegate.queryAvailable(prefix);
             if (available != null) {
                 for (String spec : available) {

--- a/core/src/main/java/org/wildfly/extras/patch/repository/SmartPatchAdapter.java
+++ b/core/src/main/java/org/wildfly/extras/patch/repository/SmartPatchAdapter.java
@@ -39,17 +39,17 @@ public class SmartPatchAdapter {
         SmartPatchAdapter result = new SmartPatchAdapter();
         result.dataHandler = smartPatch.getDataHandler();
         result.patch = PatchAdapter.fromPatch(smartPatch.getPatch());
-        List<Record> removeSet = new ArrayList<>(smartPatch.getRemoveSet());
+        List<Record> removeSet = new ArrayList<Record>(smartPatch.getRemoveSet());
         result.removeRecs = new String[removeSet.size()];
         for (int i = 0; i < removeSet.size(); i++) {
             result.removeRecs[i] = removeSet.get(i).toString();
         }
-        List<Record> replaceSet = new ArrayList<>(smartPatch.getReplaceSet());
+        List<Record> replaceSet = new ArrayList<Record>(smartPatch.getReplaceSet());
         result.replaceRecs = new String[replaceSet.size()];
         for (int i = 0; i < replaceSet.size(); i++) {
             result.replaceRecs[i] = replaceSet.get(i).toString();
         }
-        List<Record> addSet = new ArrayList<>(smartPatch.getAddSet());
+        List<Record> addSet = new ArrayList<Record>(smartPatch.getAddSet());
         result.addRecs = new String[addSet.size()];
         for (int i = 0; i < addSet.size(); i++) {
             result.addRecs[i] = addSet.get(i).toString();

--- a/core/src/main/java/org/wildfly/extras/patch/utils/IOUtils.java
+++ b/core/src/main/java/org/wildfly/extras/patch/utils/IOUtils.java
@@ -65,8 +65,8 @@ public class IOUtils {
             for (File sub : dir.listFiles()) {
                 if (sub.isDirectory()) {
                     dirs.push(sub);
-                    File relpath = new File(sourceDir.toURI().relativize(sub.toURI()));
-                    new File(targetDir, relpath.getPath()).mkdirs();
+                    String relpath = sourceDir.toURI().relativize(sub.toURI()).toString();
+                    new File(targetDir, relpath).mkdirs();
                 }
             }
         }

--- a/core/src/main/java/org/wildfly/extras/patch/utils/IOUtils.java
+++ b/core/src/main/java/org/wildfly/extras/patch/utils/IOUtils.java
@@ -19,15 +19,12 @@
  */
 package org.wildfly.extras.patch.utils;
 
-import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedList;
 import java.util.zip.CRC32;
 
 public class IOUtils {
@@ -57,50 +54,87 @@ public class IOUtils {
         output.flush();
     }
 
-    public static void copydirs(final Path targetDir, final Path sourceDir) throws IOException {
+    public static void copydirs(final File targetDir, final File sourceDir) throws IOException {
         IllegalArgumentAssertion.assertNotNull(targetDir, "targetDir");
         IllegalArgumentAssertion.assertNotNull(sourceDir, "sourceDir");
-        Files.walkFileTree(sourceDir, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                Path targetdir = targetDir.resolve(dir.relativize(sourceDir));
-                targetdir.toFile().mkdirs();
-                return FileVisitResult.CONTINUE;
-            }
 
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                return FileVisitResult.CONTINUE;
+        LinkedList<File> dirs = new LinkedList<File>();
+        dirs.push(sourceDir);
+        File dir;
+        while ((dir = dirs.poll()) != null) {
+            for (File sub : dir.listFiles()) {
+                if (sub.isDirectory()) {
+                    dirs.push(sub);
+                    File relpath = new File(sourceDir.toURI().relativize(sub.toURI()));
+                    new File(targetDir, relpath.getPath()).mkdirs();
+                }
             }
-        });
+        }
     }
 
-    public static void rmdirs(final Path targetDir) throws IOException {
+    public static void rmdirs(final File targetDir) throws IOException {
         IllegalArgumentAssertion.assertNotNull(targetDir, "targetDir");
-        if (targetDir.toFile().exists()) {
-            Files.walkFileTree(targetDir, new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                    Files.delete(dir);
-                    return FileVisitResult.CONTINUE;
-                }
 
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    Files.delete(file);
-                    return FileVisitResult.CONTINUE;
+        if (targetDir.exists()) {
+            LinkedList<File> dirs = new LinkedList<File>();
+            dirs.push(targetDir);
+            LinkedList<File> toDelete = new LinkedList<File>();
+            toDelete.push(targetDir);
+            File dir;
+            while ((dir = dirs.poll()) != null) {
+                for (File sub : dir.listFiles()) {
+                    if (sub.isDirectory()) {
+                        dirs.push(sub);
+                        toDelete.push(sub);
+                    } else {
+                        sub.delete();
+                    }
                 }
-            });
+            }
+            while ((dir = toDelete.pollLast()) != null) {
+                dir.delete();
+            }
+        }
+    }
+
+    public static class Crc32Stream extends OutputStream {
+        private CRC32 crc32;
+
+        public Crc32Stream() {
+            crc32 = new CRC32();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            crc32.update(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            crc32.update(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            crc32.update(b, off, len);
+        }
+
+        public long getValue() {
+            return crc32.getValue();
         }
     }
     
-    public static long getCRC32 (Path path) throws IOException {
+    public static long getCRC32 (File path) throws IOException {
         IllegalArgumentAssertion.assertNotNull(path, "path");
-        IllegalStateAssertion.assertTrue(path.toFile().isFile(), "Invalid file path: " + path);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Files.copy(path, baos);
-        CRC32 crc32 = new CRC32();
-        crc32.update(baos.toByteArray());
-        return crc32.getValue();
+        IllegalStateAssertion.assertTrue(path.isFile(), "Invalid file path: " + path);
+
+        Crc32Stream crc32Stream = new Crc32Stream();
+        InputStream input = new FileInputStream(path);
+        try {
+            copy(input, crc32Stream);
+        } finally {
+            input.close();
+        }
+        return crc32Stream.getValue();
     } 
 }

--- a/core/src/test/java/org/wildfly/extras/patch/repository/ParserAccess.java
+++ b/core/src/test/java/org/wildfly/extras/patch/repository/ParserAccess.java
@@ -32,8 +32,11 @@ public final class ParserAccess {
 
     public static Patch getPatch(URL zipurl) throws IOException {
         PatchId patchId = PatchId.fromURL(zipurl);
-        try (ZipInputStream zipInput = new ZipInputStream(zipurl.openStream())) {
+        ZipInputStream zipInput = new ZipInputStream(zipurl.openStream());
+        try {
             return MetadataParser.buildPatchFromZip(patchId, Record.Action.ADD, zipInput);
+        } finally {
+            zipInput.close();
         }
     }
 

--- a/core/src/test/java/org/wildfly/extras/patch/test/AetherRepositoryTest.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/AetherRepositoryTest.java
@@ -22,8 +22,6 @@ package org.wildfly.extras.patch.test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.BeforeClass;
 import org.wildfly.extras.patch.PatchTool;
@@ -37,10 +35,10 @@ public class AetherRepositoryTest extends AbstractRepositoryTest {
     @BeforeClass
     public static void setUp() throws Exception {
         for (int i = 0; i < repoURL.length; i++) {
-            Path path = Paths.get("target/repos/AetherRepositoryTest/repo" + (i + 1));
-            repoURL[i] = path.toFile().toURI().toURL();
+            File path = new File("target/repos/AetherRepositoryTest/repo" + (i + 1));
+            repoURL[i] = path.toURI().toURL();
             IOUtils.rmdirs(path);
-            path.toFile().mkdirs();
+            path.mkdirs();
         }
     }
 
@@ -52,7 +50,7 @@ public class AetherRepositoryTest extends AbstractRepositoryTest {
     PatchTool getPatchTool(final URL repoURL) {
         AetherFactory factory = new DefaultAetherFactory() {
             
-            Path rootPath = new File(repoURL.getPath()).toPath();
+            File rootPath = new File(repoURL.getPath());
             {
                 try {
                     IOUtils.rmdirs(rootPath);
@@ -67,8 +65,8 @@ public class AetherRepositoryTest extends AbstractRepositoryTest {
             }
             
             @Override
-            public Path getLocalRepositoryPath() {
-                return rootPath.resolve("local-repo");
+            public File getLocalRepositoryPath() {
+                return new File(rootPath, "local-repo");
             }
         };
         return new PatchToolBuilder().repositoryURL(repoURL).aetherFactory(factory).build();

--- a/core/src/test/java/org/wildfly/extras/patch/test/Archives.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/Archives.java
@@ -22,15 +22,11 @@ package org.wildfly.extras.patch.test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -40,6 +36,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.wildfly.extras.patch.Patch;
+import org.wildfly.extras.patch.PatchId;
 import org.wildfly.extras.patch.Record;
 import org.wildfly.extras.patch.test.subA.ClassA;
 
@@ -54,7 +51,7 @@ class Archives {
      * lib/foo-1.0.0.jar
      */
     static URL getZipUrlFoo100() throws IOException {
-        File targetFile = Paths.get("target/foo-1.0.0.zip").toFile();
+        File targetFile = new File("target/foo-1.0.0.zip");
         if (!targetFile.exists()) {
             JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "foo-1.0.0.jar");
             jar.addClasses(ClassA.class);
@@ -74,7 +71,7 @@ class Archives {
      * config/propsA.properties
      */
     static URL getZipUrlFoo100SP1() throws IOException {
-        File targetFile = Paths.get("target/foo-1.0.0.SP1.zip").toFile();
+        File targetFile = new File("target/foo-1.0.0.SP1.zip");
         if (!targetFile.exists()) {
             GenericArchive archive = ShrinkWrap.create(GenericArchive.class);
             archive.add(new FileAsset(new File("src/test/resources/propsA2.properties")), "config/propsA.properties");
@@ -91,7 +88,7 @@ class Archives {
      * lib/foo-1.1.0.jar
      */
     static URL getZipUrlFoo110() throws IOException {
-        File targetFile = Paths.get("target/foo-1.1.0.zip").toFile();
+        File targetFile = new File("target/foo-1.1.0.zip");
         if (!targetFile.exists()) {
             JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "foo-1.1.0.jar");
             jar.addClasses(ClassA.class);
@@ -111,7 +108,7 @@ class Archives {
      * lib/bar-1.0.0.jar
      */
     static URL getZipUrlBar100() throws IOException {
-        File targetFile = Paths.get("target/bar-1.0.0.zip").toFile();
+        File targetFile = new File("target/bar-1.0.0.zip");
         if (!targetFile.exists()) {
             JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "bar-1.0.0.jar");
             jar.addClasses(ClassA.class);
@@ -128,31 +125,37 @@ class Archives {
         Assert.assertEquals(exp.getAction() + " " + exp.getPath(), was.getAction() + " " + was.getPath());
     }
 
-    static void assertPathsEqual(final Patch expSet, final Path rootPath) throws IOException {
-        final Set<Path> expPaths = new HashSet<>();
+    static void assertPathsEqual(final Patch expSet, final File rootPath) throws IOException {
+        final Set<File> expPaths = new HashSet<File>();
         for (Record rec : expSet.getRecords()) {
             expPaths.add(rec.getPath());
         }
-        final Set<Path> wasPaths = new HashSet<>();
-        Files.walkFileTree(rootPath, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
-                Path relpath = rootPath.relativize(path);
-                if (!relpath.startsWith("fusepatch")) {
-                    wasPaths.add(relpath);
+        final Set<File> wasPaths = new HashSet<File>();
+        
+        LinkedList<File> dirs = new LinkedList<File>();
+        dirs.push(rootPath);
+        File dir;
+        while ((dir = dirs.poll()) != null) {
+            for (File sub : dir.listFiles()) {
+                if (sub.isDirectory()) {
+                    dirs.push(sub);
+                } else {
+                    File relpath = new File(rootPath.toURI().relativize(sub.toURI()));
+                    if (!relpath.getPath().startsWith("fusepatch")) {
+                        wasPaths.add(relpath);
+                    }
                 }
-                return FileVisitResult.CONTINUE;
             }
-        });
+        }
         Assert.assertEquals(expPaths, wasPaths);
     }
 
     static void assertPathsEqual(List<Record> exp, List<Record> was) {
-        final Set<Path> expPaths = new HashSet<>();
+        final Set<File> expPaths = new HashSet<File>();
         for (Record rec : exp) {
             expPaths.add(rec.getPath());
         }
-        final Set<Path> wasPaths = new HashSet<>();
+        final Set<File> wasPaths = new HashSet<File>();
         for (Record rec : was) {
             wasPaths.add(rec.getPath());
         }

--- a/core/src/test/java/org/wildfly/extras/patch/test/Archives.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/Archives.java
@@ -126,11 +126,11 @@ class Archives {
     }
 
     static void assertPathsEqual(final Patch expSet, final File rootPath) throws IOException {
-        final Set<File> expPaths = new HashSet<File>();
+        final Set<String> expPaths = new HashSet<String>();
         for (Record rec : expSet.getRecords()) {
-            expPaths.add(rec.getPath());
+            expPaths.add(rec.getPath().toString());
         }
-        final Set<File> wasPaths = new HashSet<File>();
+        final Set<String> wasPaths = new HashSet<String>();
         
         LinkedList<File> dirs = new LinkedList<File>();
         dirs.push(rootPath);
@@ -140,8 +140,8 @@ class Archives {
                 if (sub.isDirectory()) {
                     dirs.push(sub);
                 } else {
-                    File relpath = new File(rootPath.toURI().relativize(sub.toURI()));
-                    if (!relpath.getPath().startsWith("fusepatch")) {
+                    String relpath = rootPath.toURI().relativize(sub.toURI()).toString();
+                    if (!relpath.startsWith("fusepatch")) {
                         wasPaths.add(relpath);
                     }
                 }

--- a/core/src/test/java/org/wildfly/extras/patch/test/PatchDependenciesTest.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/PatchDependenciesTest.java
@@ -19,9 +19,8 @@
  */
 package org.wildfly.extras.patch.test;
 
+import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 
 import javax.activation.DataHandler;
@@ -41,16 +40,16 @@ import org.wildfly.extras.patch.utils.IOUtils;
 
 public class PatchDependenciesTest {
 
-    final static Path repoPath = Paths.get("target/repos/PatchDependenciesTest/repo");
-    final static Path serverPath = Paths.get("target/servers/PatchDependenciesTest/srvA");
+    final static File repoPath = new File("target/repos/PatchDependenciesTest/repo");
+    final static File serverPath = new File("target/servers/PatchDependenciesTest/srvA");
 
     @BeforeClass
     public static void setUp() throws Exception {
         IOUtils.rmdirs(repoPath);
-        repoPath.toFile().mkdirs();
+        repoPath.mkdirs();
         IOUtils.rmdirs(serverPath);
-        serverPath.toFile().mkdirs();
-        URL repoURL = repoPath.toFile().toURI().toURL();
+        serverPath.mkdirs();
+        URL repoURL = repoPath.toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).build();
         PatchId pid100 = patchTool.getRepository().addArchive(Archives.getZipUrlFoo100());
         URL url110 = Archives.getZipUrlFoo110();
@@ -63,7 +62,7 @@ public class PatchDependenciesTest {
     @Test
     public void testSimpleDependency() throws Exception {
 
-        URL repoURL = repoPath.toFile().toURI().toURL();
+        URL repoURL = repoPath.toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).serverPath(serverPath).build();
         
         PatchId idA = PatchId.fromURL(Archives.getZipUrlFoo100());

--- a/core/src/test/java/org/wildfly/extras/patch/test/PostCommandsTest.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/PostCommandsTest.java
@@ -19,9 +19,8 @@
  */
 package org.wildfly.extras.patch.test;
 
+import java.io.File;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import javax.activation.DataHandler;
@@ -45,24 +44,24 @@ import org.wildfly.extras.patch.utils.IOUtils;
 
 public class PostCommandsTest {
 
-    final static Path serverPath = Paths.get("target/servers/PostCommandsTest/srvA");
-    final static Path[] repoPaths = new Path[3];
+    final static File serverPath = new File("target/servers/PostCommandsTest/srvA");
+    final static File[] repoPaths = new File[3];
 
     @BeforeClass
     public static void setUp() throws Exception {
         IOUtils.rmdirs(serverPath);
-        serverPath.toFile().mkdirs();
+        serverPath.mkdirs();
         for (int i = 0; i < repoPaths.length; i++) {
-            repoPaths[i] = Paths.get("target/repos/PostCommandsTest/repo" + (i + 1));
+            repoPaths[i] = new File("target/repos/PostCommandsTest/repo" + (i + 1));
             IOUtils.rmdirs(repoPaths[i]);
-            repoPaths[i].toFile().mkdirs();
+            repoPaths[i].mkdirs();
         }
     }
 
     @Test
     public void testPostCommands() throws Exception {
 
-        URL repoURL = repoPaths[0].toFile().toURI().toURL();
+        URL repoURL = repoPaths[0].toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).serverPath(serverPath).build();
         Server server = patchTool.getServer();
         Repository repo = patchTool.getRepository();
@@ -98,13 +97,13 @@ public class PostCommandsTest {
     }
 
     @Test
-    public void testAddThroughMainWithCmd() throws Exception {
+    public void testAddThroughMainWithCmd() throws Throwable {
 
         String fileUrl = Archives.getZipUrlFoo100().toString();
-        String repoUrl = repoPaths[1].toUri().toURL().toString();
+        String repoUrl = repoPaths[1].toURI().toURL().toString();
         Main.mainInternal(new String[] {"--repository", repoUrl, "--add", fileUrl, "--add-cmd", "echo hello world"});
         
-        URL repoURL = repoPaths[1].toFile().toURI().toURL();
+        URL repoURL = repoPaths[1].toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).build();
         Repository repo = patchTool.getRepository();
         
@@ -114,14 +113,14 @@ public class PostCommandsTest {
     }
 
     @Test
-    public void testAddThroughMainWithMetadata() throws Exception {
+    public void testAddThroughMainWithMetadata() throws Throwable {
 
         String fileUrl = Archives.getZipUrlFoo100().toString();
-        String repoUrl = repoPaths[2].toUri().toURL().toString();
-        String metadataUrl = Paths.get("src/test/resources/simple-metadata.xml").toUri().toString();
+        String repoUrl = repoPaths[2].toURI().toURL().toString();
+        String metadataUrl = new File("src/test/resources/simple-metadata.xml").toURI().toString();
         Main.mainInternal(new String[] {"--repository", repoUrl, "--add", fileUrl, "--metadata", metadataUrl});
         
-        URL repoURL = repoPaths[2].toFile().toURI().toURL();
+        URL repoURL = repoPaths[2].toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).build();
         Repository repo = patchTool.getRepository();
         

--- a/core/src/test/java/org/wildfly/extras/patch/test/RemoveDirOnUpdateTest.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/RemoveDirOnUpdateTest.java
@@ -22,8 +22,6 @@ package org.wildfly.extras.patch.test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.GenericArchive;
@@ -51,19 +49,19 @@ import org.wildfly.extras.patch.utils.IOUtils;
  */
 public class RemoveDirOnUpdateTest {
 
-    final static Path repoPath = Paths.get("target/repos/RemoveDirOnUpdateTest/repo");
-    final static Path[] serverPaths = new Path[2];
+    final static File repoPath = new File("target/repos/RemoveDirOnUpdateTest/repo");
+    final static File[] serverPaths = new File[2];
 
     @BeforeClass
     public static void setUp() throws Exception {
         IOUtils.rmdirs(repoPath);
-        repoPath.toFile().mkdirs();
+        repoPath.mkdirs();
         for (int i = 0; i < 2; i++) {
-            serverPaths[i] = Paths.get("target/servers/RemoveDirOnUpdateTest/srv" + (i + 1));
+            serverPaths[i] = new File("target/servers/RemoveDirOnUpdateTest/srv" + (i + 1));
             IOUtils.rmdirs(serverPaths[i]);
-            serverPaths[i].toFile().mkdirs();
+            serverPaths[i].mkdirs();
         }
-        URL repoURL = repoPath.toFile().toURI().toURL();
+        URL repoURL = repoPath.toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).build();
         patchTool.getRepository().addArchive(getZipUrlRdou100());
         patchTool.getRepository().addArchive(getZipUrlRdou110());
@@ -72,12 +70,12 @@ public class RemoveDirOnUpdateTest {
     @Test
     public void testRemoveDirOnUpdate() throws Exception {
 
-        URL repoURL = repoPath.toFile().toURI().toURL();
+        URL repoURL = repoPath.toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).serverPath(serverPaths[0]).build();
         Server server = patchTool.getServer();
         
-        Path configPath = serverPaths[0].resolve("config");
-        Path subPath = configPath.resolve("sub");
+        File configPath = new File(serverPaths[0], "config");
+        File subPath = new File(configPath, "sub");
         
         Patch curSet = patchTool.install(PatchId.fromString("rdou-1.0.0"), false);
         Assert.assertEquals(2, curSet.getRecords().size());
@@ -92,8 +90,8 @@ public class RemoveDirOnUpdateTest {
         Assert.assertEquals(ManagedPath.fromString("lib/rdou-1.0.0.jar [rdou-1.0.0]"), mpaths.get(4));
 
         // Verify that the config dir exists
-        Assert.assertTrue(configPath.toFile().isDirectory());
-        Assert.assertTrue(subPath.toFile().isDirectory());
+        Assert.assertTrue(configPath.isDirectory());
+        Assert.assertTrue(subPath.isDirectory());
         
         curSet = patchTool.update("rdou", false);
         Assert.assertEquals(1, curSet.getRecords().size());
@@ -105,22 +103,22 @@ public class RemoveDirOnUpdateTest {
         Assert.assertEquals(ManagedPath.fromString("lib/rdou-1.1.0.jar [rdou-1.1.0]"), mpaths.get(1));
 
         // Verify that the config dir was removed
-        Assert.assertFalse(subPath.toFile().exists());
-        Assert.assertFalse(configPath.toFile().exists());
+        Assert.assertFalse(subPath.exists());
+        Assert.assertFalse(configPath.exists());
     }
 
     @Test
     public void testKeepDirOnUpdate() throws Exception {
 
-        URL repoURL = repoPath.toFile().toURI().toURL();
+        URL repoURL = repoPath.toURI().toURL();
         PatchTool patchTool = new PatchToolBuilder().repositoryURL(repoURL).serverPath(serverPaths[1]).build();
         Server server = patchTool.getServer();
         
-        Path configPath = serverPaths[1].resolve("config");
-        Path subPath = configPath.resolve("sub");
+        File configPath = new File(serverPaths[1], "config");
+        File subPath = new File(configPath, "sub");
         
         // Create the config path upfront
-        configPath.toFile().mkdirs();
+        configPath.mkdirs();
         
         Patch curSet = patchTool.install(PatchId.fromString("rdou-1.0.0"), false);
         Assert.assertEquals(2, curSet.getRecords().size());
@@ -134,8 +132,8 @@ public class RemoveDirOnUpdateTest {
         Assert.assertEquals(ManagedPath.fromString("lib/rdou-1.0.0.jar [rdou-1.0.0]"), mpaths.get(3));
 
         // Verify that the config dir exists
-        Assert.assertTrue(configPath.toFile().isDirectory());
-        Assert.assertTrue(subPath.toFile().isDirectory());
+        Assert.assertTrue(configPath.isDirectory());
+        Assert.assertTrue(subPath.isDirectory());
         
         curSet = patchTool.update("rdou", false);
         Assert.assertEquals(1, curSet.getRecords().size());
@@ -147,8 +145,8 @@ public class RemoveDirOnUpdateTest {
         Assert.assertEquals(ManagedPath.fromString("lib/rdou-1.1.0.jar [rdou-1.1.0]"), mpaths.get(1));
 
         // Verify that the config dir was removed
-        Assert.assertFalse(subPath.toFile().exists());
-        Assert.assertTrue(configPath.toFile().exists());
+        Assert.assertFalse(subPath.exists());
+        Assert.assertTrue(configPath.exists());
     }
 
     /**
@@ -158,7 +156,7 @@ public class RemoveDirOnUpdateTest {
      * lib/rdou-1.0.0.jar
      */
     static URL getZipUrlRdou100() throws IOException {
-        File targetFile = Paths.get("target/rdou-1.0.0.zip").toFile();
+        File targetFile = new File("target/rdou-1.0.0.zip");
         if (!targetFile.exists()) {
             JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "rdou-1.0.0.jar");
             jar.addClasses(ClassA.class);
@@ -176,7 +174,7 @@ public class RemoveDirOnUpdateTest {
      * lib/rdou-1.1.0.jar
      */
     static URL getZipUrlRdou110() throws IOException {
-        File targetFile = Paths.get("target/rdou-1.1.0.zip").toFile();
+        File targetFile = new File("target/rdou-1.1.0.zip");
         if (!targetFile.exists()) {
             JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "rdou-1.1.0.jar");
             jar.addClasses(ClassA.class);

--- a/core/src/test/java/org/wildfly/extras/patch/test/WildFlyServerCleanUpTest.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/WildFlyServerCleanUpTest.java
@@ -68,15 +68,14 @@ public class WildFlyServerCleanUpTest {
 
         // Make sure the correct jars and the module.xml remain
         assertExpectedFileCount(patchModule, 3);
-        assertExpectedFileCount(configModule, 3);
-
         Assert.assertTrue(new File(patchModule, "fuse-patch-core-1.0.1.jar").exists());
         Assert.assertTrue(new File(patchModule, "fuse-patch-core-test-1.0.1.jar").exists());
         Assert.assertTrue(new File(patchModule, "module.xml").exists());
 
-        Assert.assertTrue(new File(patchModule, "fuse-patch-config-1.0.1.jar").exists());
-        Assert.assertTrue(new File(patchModule, "fuse-patch-config-test-1.0.1.jar").exists());
-        Assert.assertTrue(new File(patchModule, "module.xml").exists());
+        assertExpectedFileCount(configModule, 3);
+        Assert.assertTrue(new File(configModule, "fuse-patch-config-1.0.1.jar").exists());
+        Assert.assertTrue(new File(configModule, "fuse-patch-config-test-1.0.1.jar").exists());
+        Assert.assertTrue(new File(configModule, "module.xml").exists());
     }
 
     @Test

--- a/core/src/test/java/org/wildfly/extras/patch/test/WildFlyServerCleanUpTest.java
+++ b/core/src/test/java/org/wildfly/extras/patch/test/WildFlyServerCleanUpTest.java
@@ -22,54 +22,30 @@ package org.wildfly.extras.patch.test;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.wildfly.extras.patch.PatchId;
 import org.wildfly.extras.patch.PatchTool;
 import org.wildfly.extras.patch.PatchToolBuilder;
 import org.wildfly.extras.patch.Server;
+import org.wildfly.extras.patch.utils.IOUtils;
 
 public class WildFlyServerCleanUpTest {
 
-    private static Path SERVER_PATH = Paths.get("target/my-server");
-    private static Path MODULE_BASE_PATH = Paths.get("target/my-server/modules/system/layers/fuse/org/wildfly/extras");
+    private static File SERVER_PATH = new File("target/my-server");
+    private static File MODULE_BASE_PATH = new File("target/my-server/modules/system/layers/fuse/org/wildfly/extras");
 
     @Before
     public void setUp() throws Exception {
-        SERVER_PATH.resolve("fusepatch/repository").toFile().mkdirs();
+        new File(SERVER_PATH, "fusepatch/repository").mkdirs();
     }
 
     @After
     public void tearDown() throws Exception {
-        Files.walkFileTree(SERVER_PATH, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exception) throws IOException {
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exception) throws IOException {
-                if (exception == null) {
-                    Files.delete(dir);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-        });
+        IOUtils.rmdirs(SERVER_PATH);
     }
 
     @Test
@@ -78,11 +54,11 @@ public class WildFlyServerCleanUpTest {
         PatchTool patchTool = builder.serverPath(SERVER_PATH).build();
         Server server = patchTool.getServer();
 
-        writeDummyModule(MODULE_BASE_PATH.resolve("patch/main"), "fuse-patch-core", true);
-        writeDummyModule(MODULE_BASE_PATH.resolve("config/main"), "fuse-patch-config", true);
+        writeDummyModule(new File(MODULE_BASE_PATH, "patch/main"), "fuse-patch-core", true);
+        writeDummyModule(new File(MODULE_BASE_PATH, "config/main"), "fuse-patch-config", true);
 
-        Path patchModule = MODULE_BASE_PATH.resolve("patch/main");
-        Path configModule = MODULE_BASE_PATH.resolve("config/main");
+        File patchModule = new File(MODULE_BASE_PATH, "patch/main");
+        File configModule = new File(MODULE_BASE_PATH, "config/main");
 
         // Assert files present before cleanup
         assertExpectedFileCount(patchModule, 5);
@@ -94,13 +70,13 @@ public class WildFlyServerCleanUpTest {
         assertExpectedFileCount(patchModule, 3);
         assertExpectedFileCount(configModule, 3);
 
-        Assert.assertTrue(patchModule.resolve("fuse-patch-core-1.0.1.jar").toFile().exists());
-        Assert.assertTrue(patchModule.resolve("fuse-patch-core-test-1.0.1.jar").toFile().exists());
-        Assert.assertTrue(patchModule.resolve("module.xml").toFile().exists());
+        Assert.assertTrue(new File(patchModule, "fuse-patch-core-1.0.1.jar").exists());
+        Assert.assertTrue(new File(patchModule, "fuse-patch-core-test-1.0.1.jar").exists());
+        Assert.assertTrue(new File(patchModule, "module.xml").exists());
 
-        Assert.assertTrue(configModule.resolve("fuse-patch-config-1.0.1.jar").toFile().exists());
-        Assert.assertTrue(configModule.resolve("fuse-patch-config-test-1.0.1.jar").toFile().exists());
-        Assert.assertTrue(configModule.resolve("module.xml").toFile().exists());
+        Assert.assertTrue(new File(patchModule, "fuse-patch-config-1.0.1.jar").exists());
+        Assert.assertTrue(new File(patchModule, "fuse-patch-config-test-1.0.1.jar").exists());
+        Assert.assertTrue(new File(patchModule, "module.xml").exists());
     }
 
     @Test
@@ -109,11 +85,11 @@ public class WildFlyServerCleanUpTest {
         PatchTool patchTool = builder.serverPath(SERVER_PATH).build();
         Server server = patchTool.getServer();
 
-        writeDummyModule(MODULE_BASE_PATH.resolve("patch/main"), "fuse-patch-core", false);
-        writeDummyModule(MODULE_BASE_PATH.resolve("config/main"), "fuse-patch-config", false);
+        writeDummyModule(new File(MODULE_BASE_PATH, "patch/main"), "fuse-patch-core", false);
+        writeDummyModule(new File(MODULE_BASE_PATH, "config/main"), "fuse-patch-config", false);
 
-        Path patchModule = MODULE_BASE_PATH.resolve("patch/main");
-        Path configModule = MODULE_BASE_PATH.resolve("config/main");
+        File patchModule = new File(MODULE_BASE_PATH, "patch/main");
+        File configModule = new File(MODULE_BASE_PATH, "config/main");
 
         assertExpectedFileCount(patchModule, 3);
         assertExpectedFileCount(configModule, 3);
@@ -124,31 +100,34 @@ public class WildFlyServerCleanUpTest {
         assertExpectedFileCount(configModule, 3);
     }
 
-    private void assertExpectedFileCount(Path modulePath, int count) {
+    private void assertExpectedFileCount(File modulePath, int count) {
         FilenameFilter filter = new ModuleFileFilter();
-        String[] moduleFiles = modulePath.toFile().list(filter);
+        String[] moduleFiles = modulePath.list(filter);
 
         Assert.assertEquals("Expected " + count + " files to be present after clean up", count, moduleFiles.length);
     }
 
-    private void writeDummyModule(Path modulePath, String name, boolean addOldVersion) throws Exception {
-        modulePath.toFile().mkdirs();
+    private void writeDummyModule(File modulePath, String name, boolean addOldVersion) throws Exception {
+        modulePath.mkdirs();
 
-        try (FileWriter fw = new FileWriter(modulePath.resolve("module.xml").toFile())) {
+        FileWriter fw = new FileWriter(new File(modulePath, "module.xml"));
+        try {
             fw.write("<module name=\"" + name + "\">\n");
             fw.write("<resources>\n");
             fw.write("<resource-root path=\"" + name + "-1.0.1.jar\"/>\n");
             fw.write("<resource-root path=\"" + name + "-test-1.0.1.jar\"/>\n");
             fw.write("</resources>\n");
             fw.write("</module>");
+        } finally {
+            fw.close();
         }
 
-        modulePath.resolve(name + "-1.0.1.jar").toFile().createNewFile();
-        modulePath.resolve(name + "-test-1.0.1.jar").toFile().createNewFile();
+        new File(modulePath, name + "-1.0.1.jar").createNewFile();
+        new File(modulePath, name + "-test-1.0.1.jar").createNewFile();
 
         if (addOldVersion) {
-            modulePath.resolve(name + "-1.0.0.jar").toFile().createNewFile();
-            modulePath.resolve(name + "-test-1.0.0.jar").toFile().createNewFile();
+            new File(modulePath, name + "-1.0.0.jar").createNewFile();
+            new File(modulePath, name + "-test-1.0.0.jar").createNewFile();
         }
     }
 

--- a/distro/standalone/scripts/assembly-directory.xml
+++ b/distro/standalone/scripts/assembly-directory.xml
@@ -22,6 +22,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
 
+    <id>assembly-directory</id>
     <formats>
         <format>dir</format>
     </formats>

--- a/distro/standalone/scripts/assembly-distro.xml
+++ b/distro/standalone/scripts/assembly-distro.xml
@@ -22,6 +22,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
 
+    <id>assembly-distro</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/installer/src/main/java/org/wildfly/extras/patch/installer/Support.java
+++ b/installer/src/main/java/org/wildfly/extras/patch/installer/Support.java
@@ -64,12 +64,15 @@ final class Support {
 
     static long computeCRC32(File file) throws IOException {
         CRC32 crc32 = new CRC32();
-        try (FileInputStream is = new FileInputStream(file)) {
+        FileInputStream is = new FileInputStream(file);
+        try {
             int len;
             byte[] buffer = new byte[1024 * 4];
             while ((len = is.read(buffer)) > 0) {
                 crc32.update(buffer, 0, len);
             }
+        } finally {
+            is.close();
         }
         return crc32.getValue();
     }

--- a/installer/src/main/java/org/wildfly/extras/patch/installer/Version.java
+++ b/installer/src/main/java/org/wildfly/extras/patch/installer/Version.java
@@ -337,7 +337,7 @@ public class Version implements Comparable<Version> {
 
         ListItem list = items;
 
-        Stack<Item> stack = new Stack<>();
+        Stack<Item> stack = new Stack<Item>();
         stack.push(list);
 
         boolean isDigit = false;

--- a/installer/src/main/java/org/wildfly/extras/patch/installer/internal/Main.java
+++ b/installer/src/main/java/org/wildfly/extras/patch/installer/internal/Main.java
@@ -37,6 +37,6 @@ public final class Main {
                 return "fuse-patch-installer.jar";
             }
         };
-        installer.main(new LinkedList<>(Arrays.asList(originalArgs)));
+        installer.main(new LinkedList<String>(Arrays.asList(originalArgs)));
     }
 }

--- a/itests/jaxws/src/test/java/org/wildfly/extras/patch/test/RepositoryEndpointTest.java
+++ b/itests/jaxws/src/test/java/org/wildfly/extras/patch/test/RepositoryEndpointTest.java
@@ -25,8 +25,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import javax.activation.DataHandler;
@@ -186,13 +184,16 @@ public class RepositoryEndpointTest {
 	}
 
 	private URL getArchiveURL(String name) throws IOException {
-    	Path dataDir = Paths.get(System.getProperty("jboss.server.data.dir"));
-    	Path patchDir = dataDir.resolve("fusepatch");
-    	patchDir.toFile().mkdirs();
-    	File patchFile = patchDir.resolve(name + ".zip").toFile();
+    	File dataDir = new File(System.getProperty("jboss.server.data.dir"));
+    	File patchDir = new File(dataDir, "fusepatch");
+    	patchDir.mkdirs();
+    	File patchFile = new File(patchDir, name + ".zip");
     	if (!patchFile.isFile()) {
-        	try (InputStream input = deployer.getDeployment(name)) {
+    	    InputStream input = deployer.getDeployment(name);
+        	try {
         		IOUtils.copy(input, new FileOutputStream(patchFile));
+        	} finally {
+        	    input.close();
         	}
     	}
 		return patchFile.toURI().toURL();

--- a/jaxws/src/main/java/org/wildfly/extras/patch/jaxws/RepositoryEndpoint.java
+++ b/jaxws/src/main/java/org/wildfly/extras/patch/jaxws/RepositoryEndpoint.java
@@ -70,7 +70,7 @@ public class RepositoryEndpoint implements RepositoryService {
 	public String[] queryAvailable(String prefix) {
         lock.tryLock();
         try {
-            List<String> result = new ArrayList<>();
+            List<String> result = new ArrayList<String>();
             for (PatchId pid : delegate.queryAvailable(prefix)) {
                 result.add(pid.toString());
             }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <version-exec-maven-plugin>1.4.0</version-exec-maven-plugin>
         <version-license-maven-plugin>1.8</version-license-maven-plugin>
         <version-groovy-maven-plugin>2.0</version-groovy-maven-plugin>
+        <version-maven-assembly-plugin>2.6</version-maven-assembly-plugin>
         <version-maven-compiler-plugin>3.1</version-maven-compiler-plugin>
         <version-maven-jar-plugin>2.6</version-maven-jar-plugin>
         <version-maven-javadoc-plugin>2.9.1</version-maven-javadoc-plugin>
@@ -178,6 +179,11 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${version-maven-assembly-plugin}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -189,8 +189,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version-maven-compiler-plugin}</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.6</source>
+                        <target>1.6</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
 
     <!-- Properties -->
     <properties>
+        <!-- maven-resources-plugin -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <!-- WildFly version -->
         <version.wildfly>10.0.0.Final</version.wildfly>
         

--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,13 @@
         <module>config</module>
         <module>core</module>
         <module>distro</module>
+        <!--
         <module>docs</module>
         <module>feature</module>
         <module>installer</module>
         <module>jaxws</module>
         <module>itests</module>
+        -->
     </modules>
 
     <!-- Dependency Management -->

--- a/pom.xml
+++ b/pom.xml
@@ -78,13 +78,11 @@
         <module>config</module>
         <module>core</module>
         <module>distro</module>
-        <!--
         <module>docs</module>
         <module>feature</module>
         <module>installer</module>
         <module>jaxws</module>
         <module>itests</module>
-        -->
     </modules>
 
     <!-- Dependency Management -->


### PR DESCRIPTION
I have the unfortunate requirement of JDK 6 for DV 6.x. This pull request would remove a barrier to using fuse-patch for products like DV with existing maintenance requirements.

The changes are slightly less ugly than I anticipated. The legacy `File` API was used in many places, hidden behind `.toFile()` calls from `Path` objects.

All unit and integration tests pass, but I'm not sure how comprehensive they are. They did flag some problems, which I have corrected.